### PR TITLE
PSST-3633: Add support for `isolated` parameter

### DIFF
--- a/man/systemd.network.xml
+++ b/man/systemd.network.xml
@@ -2684,6 +2684,15 @@ IPv6Token=prefixstable:2002:da8:1::</programlisting></para>
           </listitem>
         </varlistentry>
         <varlistentry>
+          <term><varname>Isolated=</varname></term>
+          <listitem>
+            <para>Takes a boolean. Configures whether this port is isolated or not. Within a bridge,
+            isolated ports can only communicate with non-isolated ports. When set to true, this port cannot
+            communicate with other ports whose Isolated setting is false.  When set to false, this port
+            can communicate with any other ports. When unset, the kernel's default will be used.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
           <term><varname>UseBPDU=</varname></term>
           <listitem>
             <para>Takes a boolean. Configures whether STP Bridge Protocol Data Units will be

--- a/src/network/netdev/bridge.c
+++ b/src/network/netdev/bridge.c
@@ -211,6 +211,12 @@ int link_set_bridge(Link *link) {
                         return log_link_error_errno(link, r, "Could not append IFLA_BRPORT_MODE attribute: %m");
         }
 
+        if (link->network->isolated >= 0) {
+                r = sd_netlink_message_append_u8(req, IFLA_BRPORT_ISOLATED, link->network->isolated);
+                if (r < 0)
+                        return log_link_error_errno(link, r, "Could not append IFLA_BRPORT_ISOLATED attribute: %m");
+        }
+
         if (link->network->fast_leave >= 0) {
                 r = sd_netlink_message_append_u8(req, IFLA_BRPORT_FAST_LEAVE, link->network->fast_leave);
                 if (r < 0)

--- a/src/network/networkd-network-gperf.gperf
+++ b/src/network/networkd-network-gperf.gperf
@@ -285,6 +285,7 @@ DHCPServer.BindToInterface,                  config_parse_bool,                 
 Bridge.Cost,                                 config_parse_uint32,                                      0,                             offsetof(Network, cost)
 Bridge.UseBPDU,                              config_parse_tristate,                                    0,                             offsetof(Network, use_bpdu)
 Bridge.HairPin,                              config_parse_tristate,                                    0,                             offsetof(Network, hairpin)
+Bridge.Isolated,                             config_parse_tristate,                                    0,                             offsetof(Network, isolated)
 Bridge.FastLeave,                            config_parse_tristate,                                    0,                             offsetof(Network, fast_leave)
 Bridge.AllowPortToBeRoot,                    config_parse_tristate,                                    0,                             offsetof(Network, allow_port_to_be_root)
 Bridge.UnicastFlood,                         config_parse_tristate,                                    0,                             offsetof(Network, unicast_flood)

--- a/src/network/networkd-network.c
+++ b/src/network/networkd-network.c
@@ -343,6 +343,7 @@ int network_load_one(Manager *manager, OrderedHashmap **networks, const char *fi
 
                 .use_bpdu = -1,
                 .hairpin = -1,
+                .isolated = -1,
                 .fast_leave = -1,
                 .allow_port_to_be_root = -1,
                 .unicast_flood = -1,

--- a/src/network/networkd-network.h
+++ b/src/network/networkd-network.h
@@ -229,6 +229,7 @@ struct Network {
         /* Bridge Support */
         int use_bpdu;
         int hairpin;
+        int isolated;
         int fast_leave;
         int allow_port_to_be_root;
         int unicast_flood;

--- a/test/fuzz/fuzz-network-parser/26-bridge-slave-interface-1.network
+++ b/test/fuzz/fuzz-network-parser/26-bridge-slave-interface-1.network
@@ -7,6 +7,7 @@ Bridge=bridge99
 [Bridge]
 Cost=400
 HairPin = true
+Isolated = true
 FastLeave = true
 UnicastFlood = true
 MulticastToUnicast = true

--- a/test/fuzz/fuzz-network-parser/directives.network
+++ b/test/fuzz/fuzz-network-parser/directives.network
@@ -2,6 +2,7 @@
 Cost=
 UseBPDU=
 HairPin=
+Isolated=
 UnicastFlood=
 FastLeave=
 Priority=

--- a/test/fuzz/fuzz-unit-file/directives-all.service
+++ b/test/fuzz/fuzz-unit-file/directives-all.service
@@ -442,6 +442,7 @@ Group=
 GroupForwardMask=
 GroupPolicyExtension=
 HairPin=
+Isolated=
 MulticastToUnicast=
 HelloTimeSec=
 HomeAddress=

--- a/test/networkd-test.py
+++ b/test/networkd-test.py
@@ -267,6 +267,7 @@ Priority=0
 [Bridge]
 UnicastFlood=true
 HairPin=true
+Isolated=true
 UseBPDU=true
 FastLeave=true
 AllowPortToBeRoot=true
@@ -277,6 +278,7 @@ Priority=23
 
         self.assertEqual(self.read_attr('port2', 'brport/priority'), '23')
         self.assertEqual(self.read_attr('port2', 'brport/hairpin_mode'), '1')
+        self.assertEqual(self.read_attr('port2', 'brport/isolated'), '1')
         self.assertEqual(self.read_attr('port2', 'brport/path_cost'), '555')
         self.assertEqual(self.read_attr('port2', 'brport/multicast_fast_leave'), '1')
         self.assertEqual(self.read_attr('port2', 'brport/unicast_flood'), '1')

--- a/test/test-network/conf/26-bridge-slave-interface-1.network
+++ b/test/test-network/conf/26-bridge-slave-interface-1.network
@@ -7,6 +7,7 @@ Bridge=bridge99
 [Bridge]
 Cost=400
 HairPin = true
+Isolated = true
 FastLeave = true
 UnicastFlood = true
 MulticastFlood = false

--- a/test/test-network/systemd-networkd-tests.py
+++ b/test/test-network/systemd-networkd-tests.py
@@ -3405,6 +3405,7 @@ class NetworkdBridgeTests(unittest.TestCase, Utilities):
         print(output)
         self.assertEqual(read_bridge_port_attr('bridge99', 'dummy98', 'path_cost'), '400')
         self.assertEqual(read_bridge_port_attr('bridge99', 'dummy98', 'hairpin_mode'), '1')
+        self.assertEqual(read_bridge_port_attr('bridge99', 'dummy98', 'isolated'), '1')
         self.assertEqual(read_bridge_port_attr('bridge99', 'dummy98', 'multicast_fast_leave'), '1')
         self.assertEqual(read_bridge_port_attr('bridge99', 'dummy98', 'unicast_flood'), '1')
         self.assertEqual(read_bridge_port_attr('bridge99', 'dummy98', 'multicast_flood'), '0')


### PR DESCRIPTION
Add the `Isolated` parameter in the *.network file, e.g.,

[Bridge]
Isolated=true|false

When the Isolated parameter is true, traffic coming out of this port
will only be forward to other ports whose Isolated parameter is false.

When Isolated is not specified, the port uses the kernel default
setting (false).

The "Isolated" parameter was introduced in Linux 4.19.
See man bridge(8) for more details.
But even though the kernel and bridge/iproute2 recognize the "Isolated"
parameter, systemd-networkd did not have a way to set it.